### PR TITLE
Minor changes to match svelte.kit 1.0.0-next.29 requirements

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,8 +2,10 @@
 	"compilerOptions": {
 		"baseUrl": ".",
 		"paths": {
+			"$lib": ["src/lib"],
 			"$lib/*": ["src/lib/*"]
 		}
 	},
-	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"]
+	"include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"],
+	"extends": "./.svelte-kit/tsconfig.json"
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,7 +8,6 @@ const config = {
 	preprocess: [md.mdsvex(mdsvexConfig)],
 	kit: {
 		// hydrate the <div id="svelte"> element in src/app.html
-		target: '#svelte',
 		adapter: adapter(),
 		prerender: {
 			onError: 'continue'


### PR DESCRIPTION
As per documentation `npm i`  installs svelte.kit 1.0.0-next.29  that have new requirements.

Affected files:
svelte.config.js
jsconfig.json

Tested: OK!

